### PR TITLE
Removed macos-10.15 because it will be removed at 2023-03-31

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, windows-2019 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-11, windows-2019 ]
     runs-on: ${{ matrix.os }}
     env: # https://github.com/jruby/jruby/issues/7182
       JAVA_OPTS: -Djdk.io.File.enableADS=true


### PR DESCRIPTION
This is part of https://github.com/ruby/setup-ruby/pull/467