### PR TITLE
Index into array resulting from Hash#map

### DIFF
--- a/find-jruby-head-url.rb
+++ b/find-jruby-head-url.rb
@@ -65,7 +65,7 @@ xml = URI.open(index_url, &:read)
 STDERR.puts xml
 
 parsed = MicroXMLParser.parse(xml)
-versions = parsed.dig(:metadata, :versioning, :versions).map { |e| e[:version] }
+versions = parsed.dig(:metadata, :versioning, :versions).map { |e| e[1] }
 
 versions.delete('9000.dev-SNAPSHOT')
 most_recent = versions.max_by { |v| Gem::Version.new(v) }


### PR DESCRIPTION
Not sure why this is suddenly failing but the elements passed to this `map` block are not hashes, they are arrays. This is the simplest fix.