### PR TITLE
Pin dev builds to 9.4 for now

### DIFF
--- a/find-jruby-head-url-nokogiri.rb
+++ b/find-jruby-head-url-nokogiri.rb
@@ -12,7 +12,7 @@ STDERR.puts xml
 versions = Nokogiri::XML(xml).css('version').map(&:text)
 
 versions.delete('9000.dev-SNAPSHOT')
-most_recent = versions.max_by { |v| Gem::Version.new(v) }
+most_recent = versions.grep(/9\.4/).max_by { |v| Gem::Version.new(v) }
 
 builds_url = "#{base_url}/#{most_recent}/maven-metadata.xml"
 STDERR.puts builds_url


### PR DESCRIPTION
JRuby 10 is about to become the new "jruby-head" but we want to ease into that transition. This PR filters available snapshot versions to just "9.4" releases until we are ready to support 10.