### PR TITLE
Add jruby on windows-11-arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm, macos-13, macos-14, windows-2019 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm, macos-13, macos-14, windows-2019, windows-11-arm ]
     runs-on: ${{ matrix.os }}
     outputs:
       commit: ${{ steps.latest_commit.outputs.commit }}
@@ -89,8 +89,8 @@ jobs:
         platform=${{ matrix.os }}
         platform=${platform/macos-13/macos-latest}
         platform=${platform/macos-14/macos-13-arm64}
-        platform=${platform/%-arm/-arm64}
-        platform=${platform/windows-*/windows-latest}
+        platform=${platform/windows-2019/windows-latest}
+        platform=${platform/windows-11-arm/windows-arm64}
         echo "platform=$platform" >> $GITHUB_OUTPUT
 
     # Build


### PR DESCRIPTION
JRuby >=9.4.4.0 supports windows on arm: https://github.com/jruby/jruby/releases/tag/9.4.4.0

GitHub Actions recently added new windows-11-arm runner for OSS: https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/

Name `windows-11-arm` is normalized to `windows-11-arm64` to align similar to how ubuntu and mac runner's names get normalized.