### PR TITLE
Fix arm to arm64 normalization for ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
         platform=${platform/macos-14/macos-13-arm64}
         platform=${platform/windows-2019/windows-latest}
         platform=${platform/windows-11-arm/windows-arm64}
+        platform=${platform/%-arm/-arm64}
         echo "platform=$platform" >> $GITHUB_OUTPUT
 
     # Build


### PR DESCRIPTION
@eregon I accidentally deleted this line when rebasing, and it created a wrong file name for ubuntu arm64.