### PR TITLE
Don't manipulate bin scripts for jruby/ruby

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,21 +115,6 @@ jobs:
         ls -l jruby-*-SNAPSHOT/bin
         mv jruby-*-SNAPSHOT jruby-head
         ls -l jruby-head/bin
-    - name: Add ruby alias
-      if: "!startsWith(matrix.os, 'windows')"
-      run: |
-        cd jruby-head/bin
-        ln -s jruby ruby
-    - name: Add ruby alias (Windows)
-      if: startsWith(matrix.os, 'windows')
-      shell: bash
-      run: |
-        cd jruby-head/bin
-        # Copy bash launcher, so 'ruby' works in bash
-        cp jruby ruby
-        # Create ruby.bat, so 'ruby' works in pwsh
-        echo -en "@ECHO OFF\r\n@\"%~dp0jruby.exe\" %*\r\n" > ruby.bat
-        ls -l
     - name: Create archive
       run: tar czf jruby-head-${{ steps.platform.outputs.platform }}.tar.gz jruby-head
 


### PR DESCRIPTION
In jruby/jruby#8875 we modified JRuby's distribution to always ship scripts for bin/jruby and bin/ruby:

* bin/jruby and bin/ruby are versioned shell scripts that launch `/bin/sh bin/jruby.sh`.
* bin/ruby.bat contains batch code to launch bin/ruby.exe.
* No copying of scripts is done during the build and no tweaks are needed by installers to copy, link, or create additional bin/ commands.

These changes now conflict with jruby-dev-builder's symlinking of bin/jruby to bin/ruby and its creation of bin/ruby.bat, so we remove the relevant steps.